### PR TITLE
docs: update READMEs for post-refactor stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,11 @@ The project consists of two main folders:
 ### Client side
 [Client Documentation](/client/README.md)
 
-The client side is build with the Angular framework. For a better user-expereience the following libraries are used: 
-* NgRx - Reactive state managment for Angular inspired by Redux. Used for the user's cart.
-* ngrx-store-localstorage - Simple syncing between the NgRx store and local storage.
+The client side is built with Angular (currently v20) using standalone components and the signals-based reactivity model throughout. The cart is backed by an injectable signal store with a small `localStorageSignal` helper for persistence; routes are lazy-loaded via `loadComponent`. The following libraries / browser features are used:
 * Angular Material - Material Design components.
-* ngx-cookie-service - Angular service to read, set and delete browser cookies. Used for the authentication.
-* ng-lazyload-image - Lazy image loader.
+* ngx-cookie-service - Angular service to read, set and delete browser cookies. Used for authentication.
+* `Intl.DateTimeFormat` (browser-native) - date formatting in pipes.
+* `loading="lazy"` (browser-native) - image lazy loading.
 
 ### Server side
 [API Documentation](/server/README.md)

--- a/client/README.md
+++ b/client/README.md
@@ -1,6 +1,7 @@
 # DreamFurniture
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 17.1.0.
+Built with [Angular](https://angular.dev/) v20 (originally scaffolded on v17.1.0). The app uses standalone components, the signals-based reactivity model, lazy-loaded routes (`loadComponent`), and `OnPush` change detection across all components.
+
 The application is deployed at https://dream-furniture-1e92c.web.app
 
 ## Content table
@@ -211,7 +212,7 @@ Authenticated users can create their own wishlist and manage their favorite prod
 
 The cart is the place where the user can see his final presentation of the products he wants to buy with their price (per product, total price of the current product, overall total price). From the cart, he can manage all products (incrementing or decerementing the count of a product and removing the product from the cart). Upon removing the item from the cart, a modal is displayed and the user has to confirm he wants to remove the item from the cart.
 
-The cart utilizes the ngrx store to keep the state of the user's cart. Additionaly the ngrx-store-localstorage is used to keep the the state through the session.
+The cart state is held in `CartStore`, a `providedIn: 'root'` service that exposes a readonly `items` signal and `computed` signals for `totalCount` / `totalPrice`. Mutations go through `addItem` / `decrease` / `remove` / `reset` methods. Persistence between sessions is handled by a small `localStorageSignal` helper (`shared/local-storage-signal.ts`) — a writable signal that hydrates itself from `localStorage` on init and writes back on every change via an `effect()`.
 
 #### Cart view
 


### PR DESCRIPTION
## Summary

The READMEs still listed dependencies that the v17 → v20 modernization PR (#1) removed. This brings them in sync with reality.

## Changes

### `/README.md`
The "Client side" bullet list was advertising libraries that no longer ship with the app:
- ❌ `NgRx` — replaced by a signal-based `CartStore`.
- ❌ `ngrx-store-localstorage` — replaced by a tiny in-house `localStorageSignal` helper.
- ❌ `ng-lazyload-image` — replaced by native `loading="lazy"` on `<img>` tags.

Rewrote the section to mention Angular v20, signals + standalone components, lazy-loaded routes, and the two browser-native features (`Intl.DateTimeFormat`, `loading="lazy"`) that filled the gap.

### `/client/README.md`
- Bumped the "generated with Angular CLI" line from v17.1.0 → v20, and added a one-liner about the modern stack (signals, lazy routes, OnPush).
- Rewrote the §Cart paragraph: was "utilizes the ngrx store … additionally the ngrx-store-localstorage is used" → now describes the signal-backed `CartStore` (readonly `items` signal + `computed` `totalCount` / `totalPrice`, mutations via `addItem` / `decrease` / `remove` / `reset`) and the `localStorageSignal` helper that handles persistence via `effect()`.