### PR TITLE
Fix/server security

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,15 @@
+# Copy this file to `.env` and fill in real values. `.env` is gitignored.
+
+# MongoDB connection string (MongoDB Atlas in production).
+# Format: mongodb+srv://<user>:<password>@<cluster-host>/<db>?retryWrites=true&w=majority
+DATABASE_URL=
+
+# Secret used to sign JWT auth tokens. Generate a strong value with:
+#   node -e "console.log(require('crypto').randomBytes(48).toString('hex'))"
+JWT_SECRET=
+
+# Secret used to sign cookies. Generate the same way as JWT_SECRET.
+COOKIE_SECRET=
+
+# Optional: local fallback URI used only by the seed script when DATABASE_URL is unset.
+# MONGO_URI=mongodb://127.0.0.1:27017/dream-furniture

--- a/server/config/env.js
+++ b/server/config/env.js
@@ -1,0 +1,22 @@
+require("dotenv").config();
+
+// Required at boot. No fallback values: a missing secret should crash loudly,
+// never silently sign tokens/cookies with a hardcoded default.
+const REQUIRED = ["DATABASE_URL", "JWT_SECRET", "COOKIE_SECRET"];
+
+const missing = REQUIRED.filter((key) => !process.env[key]);
+if (missing.length > 0) {
+  console.error(
+    `[config] Missing required environment variable(s): ${missing.join(", ")}`
+  );
+  console.error(
+    "Copy server/.env.example to server/.env and provide real values before starting."
+  );
+  process.exit(1);
+}
+
+module.exports = {
+  databaseUrl: process.env.DATABASE_URL,
+  jwtSecret: process.env.JWT_SECRET,
+  cookieSecret: process.env.COOKIE_SECRET,
+};

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -2,17 +2,13 @@ const express = require("express");
 const cors = require("cors");
 const { default: mongoose } = require("mongoose");
 const cookieParser = require("cookie-parser");
-require("dotenv").config();
+const { databaseUrl, cookieSecret } = require("./env");
 
 const session = require("../middlewares/session");
 const queryParams = require("../middlewares/queryParams");
 
-const connectionString =
-  process.env.DATABASE_URL || "mongodb://localhost:27017/dream-furniture";
-const cookieSecret = process.env.COOKIE_SECRET || "DreamFurniture";
-
 module.exports = async (app) => {
-  const connection = await mongoose.connect(connectionString);
+  const connection = await mongoose.connect(databaseUrl);
   console.log("Connected to Database");
 
   app.use(express.json());

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -3,6 +3,8 @@ const jwt = require("jsonwebtoken");
 const User = require("../models/User");
 const { jwtSecret: secret } = require("../config/env");
 
+const TOKEN_TTL = "7d";
+
 async function login(email, password) {
   const existingUser = await User.findOne({ email }).collation({
     locale: "en",
@@ -81,7 +83,7 @@ function createToken(user) {
       username: user.username,
       wishlist: user.wishlist,
     },
-    authToken: jwt.sign(payload, secret /*,{ expiresIn: "30s" }*/),
+    authToken: jwt.sign(payload, secret, { expiresIn: TOKEN_TTL }),
   };
 }
 

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -1,8 +1,7 @@
 const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
 const User = require("../models/User");
-
-const secret = process.env.JWT_SECRET || "whg73hdgw6";
+const { jwtSecret: secret } = require("../config/env");
 
 async function login(email, password) {
   const existingUser = await User.findOne({ email }).collation({

--- a/server/services/productService.js
+++ b/server/services/productService.js
@@ -1,5 +1,10 @@
 const Product = require("../models/Product");
 
+// Escape regex metacharacters so user input is matched literally (no ReDoS / injection).
+function escapeRegex(str) {
+  return String(str).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 async function getProducts(query) {
   let products;
   const optionsArr = [];
@@ -9,7 +14,7 @@ async function getProducts(query) {
   }
 
   if (query.search) {
-    optionsArr.push({ name: { $regex: new RegExp(query.search, "i") } });
+    optionsArr.push({ name: { $regex: new RegExp(escapeRegex(query.search), "i") } });
   }
 
   if (query.priceRange) {


### PR DESCRIPTION
Three independent, self-contained server security fixes. Targets `main`
(production deploy source) so they ship without waiting on the redesign.

### Changes
- **Secrets required at boot** (`config/env.js`): app fails fast if
  `DATABASE_URL` / `JWT_SECRET` / `COOKIE_SECRET` are missing. Removes the
  weak hardcoded fallback secrets. Adds `.env.example`.
- **Auth tokens expire** after 7 days (was: never expired).
- **Product search regex escaped**: user input in the `name` `$regex` lookup
  is now matched literally, closing a ReDoS / regex-injection vector.

### Notes
- Atlas `admin` DB user rotated to a scoped user and deleted; `JWT_SECRET`
  and `COOKIE_SECRET` rotated in `.env` and Render.
- Rotating the JWT secret + adding expiry invalidates existing sessions
  (one-time re-login).
- `productService.js` may conflict when `refactor/luxury-redesign` later
  merges — both branches touch it; trivial to resolve.