### PR TITLE
Fix/server correctness

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -86,7 +86,9 @@ authController.get("/logout", async (req, res) => {
         })
         .json({ message: "Succesfully logged out" });
     } else {
-      res.clearCookie(authCookieName, { httpOnly: false });
+      res
+        .clearCookie(authCookieName, { httpOnly: false })
+        .json({ message: "Succesfully logged out" });
     }
   } catch (error) {
     const errorMessage = errorParser(error);

--- a/server/middlewares/preload.js
+++ b/server/middlewares/preload.js
@@ -2,11 +2,17 @@ const productService = require("../services/productService");
 
 module.exports = () => {
   return async (req, res, next) => {
-    const itemId = req.params.id;
-
-    const item = await productService.getProductById(itemId);
-    res.locals.product = item;
-
-    next();
+    try {
+      const item = await productService.getProductById(req.params.id);
+      if (!item) {
+        return res.status(404).json({ message: "Product not found" });
+      }
+      res.locals.product = item;
+      next();
+    } catch (error) {
+      // Malformed id (e.g. bad ObjectId) or lookup failure — fail cleanly
+      // instead of throwing out of an async middleware.
+      res.status(400).json({ message: "Invalid product id" });
+    }
   };
 };

--- a/server/middlewares/session.js
+++ b/server/middlewares/session.js
@@ -6,12 +6,11 @@ module.exports = () => (req, res, next) => {
 
   if (token) {
     try {
-      const payload = authService.verifyToken(token);
-      req.user = payload;
-      // req.token = token;
+      req.user = authService.verifyToken(token);
     } catch (error) {
-      res.status(401).json({ message: "Invalid auth token" })
-      return;
+      // Invalid or expired token: drop the bad cookie and continue as a guest.
+      // Guards still reject protected routes; public routes stay accessible.
+      res.clearCookie(authCookieName);
     }
   }
 


### PR DESCRIPTION
Three small, independent correctness fixes for the server. Off `main`.

### Changes
- **#6 — stale cookie no longer blocks public routes.** The session
  middleware returned `401` for *any* invalid/expired token, so a user with a
  stale `auth-cookie` couldn't even browse `/products`. Now it clears the bad
  cookie and continues as a guest; guards still reject protected routes. (More
  relevant now that tokens expire after 7 days.)
- **#7 — dev-mode logout hung.** The non-production branch cleared the cookie
  but never sent a response, leaving the request open. It now responds.
- **#8 — `preload` crashed on bad input.** A malformed/missing product id threw
  out of the async middleware. It now returns `404` (not found) or `400`
  (invalid id) cleanly.

### Verification
Faked req/res unit checks confirm: no token → guest; invalid token → cookie
cleared + guest (no 401); valid token → `req.user` set; malformed id → 400.