### PR TITLE
Refactor/server hardening

### DIFF
--- a/server/config/express.js
+++ b/server/config/express.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const cors = require("cors");
+const helmet = require("helmet");
 const { default: mongoose } = require("mongoose");
 const cookieParser = require("cookie-parser");
 const { databaseUrl, cookieSecret } = require("./env");
@@ -11,7 +12,8 @@ module.exports = async (app) => {
   const connection = await mongoose.connect(databaseUrl);
   console.log("Connected to Database");
 
-  app.use(express.json());
+  app.use(helmet());
+  app.use(express.json({ limit: "100kb" }));
   app.use(cookieParser(cookieSecret));
   app.use(
     cors({

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -1,9 +1,10 @@
 const authService = require("../services/authService");
 const { authCookieName } = require("../config/cookie.js");
-const errorParser = require("../util/errorParser.js");
+const asyncHandler = require("../util/asyncHandler.js");
 
 const { body, validationResult } = require("express-validator");
 const { isGuest, isUser } = require("../middlewares/guards.js");
+const { authLimiter } = require("../middlewares/rateLimit.js");
 const wishlistService = require("../services/wishlistService.js");
 const productService = require("../services/productService.js");
 
@@ -11,30 +12,30 @@ const authController = require("express").Router();
 
 const emailPattern = "[a-zA-Z0-9]{5,}@[a-zA-Z]+.[a-zA-Z]{2,}$";
 
-authController.post("/login", isGuest(), async (req, res) => {
-  try {
+const cookieOptions =
+  process.env.NODE_ENV == "production"
+    ? { httpOnly: true, sameSite: "none", secure: true }
+    : { httpOnly: false };
+
+function setAuthCookie(res, authToken) {
+  res.cookie(authCookieName, authToken, cookieOptions);
+}
+
+authController.post(
+  "/login",
+  authLimiter,
+  isGuest(),
+  asyncHandler(async (req, res) => {
     const { email, password } = req.body;
     const { user, authToken } = await authService.login(email, password);
-
-    if (process.env.NODE_ENV == "production") {
-      res.cookie(authCookieName, authToken, {
-        httpOnly: true,
-        sameSite: "none",
-        secure: true,
-      });
-    } else {
-      res.cookie(authCookieName, authToken, { httpOnly: false });
-    }
-
+    setAuthCookie(res, authToken);
     res.json(user);
-  } catch (error) {
-    const errorMessage = errorParser(error);
-    res.status(400).json({ message: errorMessage });
-  }
-});
+  })
+);
 
 authController.post(
   "/register",
+  authLimiter,
   isGuest(),
   body("email").matches(emailPattern).withMessage("Invalid email"),
   body("username")
@@ -43,106 +44,67 @@ authController.post(
   body("password")
     .isLength({ min: 6 })
     .withMessage("Password must be atleast 6 characters long"),
-  async (req, res) => {
-    try {
-      const errors = validationResult(req).errors;
-      if (errors.length > 0) {
-        throw errors;
-      }
-
-      const { username, email, password } = req.body;
-      const { user, authToken } = await authService.register(
-        username,
-        email,
-        password
-      );
-
-      if (process.env.NODE_ENV == "production") {
-        res.cookie(authCookieName, authToken, {
-          httpOnly: true,
-          sameSite: "none",
-          secure: true,
-        });
-      } else {
-        res.cookie(authCookieName, authToken, { httpOnly: false });
-      }
-
-      res.json(user);
-    } catch (error) {
-      const errorMessage = errorParser(error);
-      res.status(400).json({ message: errorMessage });
+  asyncHandler(async (req, res) => {
+    const errors = validationResult(req).errors;
+    if (errors.length > 0) {
+      throw errors;
     }
-  }
+
+    const { username, email, password } = req.body;
+    const { user, authToken } = await authService.register(
+      username,
+      email,
+      password
+    );
+    setAuthCookie(res, authToken);
+    res.json(user);
+  })
 );
 
-authController.get("/logout", async (req, res) => {
-  try {
-    if (process.env.NODE_ENV == "production") {
-      res
-        .clearCookie(authCookieName, {
-          httpOnly: true,
-          sameSite: "none",
-          secure: true,
-        })
-        .json({ message: "Succesfully logged out" });
-    } else {
-      res
-        .clearCookie(authCookieName, { httpOnly: false })
-        .json({ message: "Succesfully logged out" });
-    }
-  } catch (error) {
-    const errorMessage = errorParser(error);
-    res.status(400).json({ message: errorMessage });
-  }
+authController.get("/logout", (req, res) => {
+  res
+    .clearCookie(authCookieName, cookieOptions)
+    .json({ message: "Succesfully logged out" });
 });
 
-authController.get("/profile", isUser(), async (req, res) => {
-  try {
-    const userId = req.user?._id;
-
-    const user = await authService.getUser(userId);
+authController.get(
+  "/profile",
+  isUser(),
+  asyncHandler(async (req, res) => {
+    const user = await authService.getUser(req.user?._id);
     res.status(200).json(user);
-  } catch (error) {
-    const errorMessage = errorParser(error);
-    res.status(400).json({ message: errorMessage });
-  }
-});
+  })
+);
 
-authController.patch("/profile", isUser(), async (req, res) => {
-  try {
-    const userId = req.user._id;
+authController.patch(
+  "/profile",
+  isUser(),
+  asyncHandler(async (req, res) => {
     const user = await authService.editUser(
-      userId,
+      req.user._id,
       req.body.username,
       req.body.email
     );
     res.json(user);
-  } catch (error) {
-    const errorMessage = errorParser(error);
-    res.status(400).json({ message: errorMessage });
-  }
-});
+  })
+);
 
-authController.get("/wishlist", isUser(), async (req, res) => {
-  try {
-    const userId = req.user?._id;
-    const wishlist = await wishlistService.getWishlist(userId);
+authController.get(
+  "/wishlist",
+  isUser(),
+  asyncHandler(async (req, res) => {
+    const wishlist = await wishlistService.getWishlist(req.user?._id);
     res.json(wishlist);
-  } catch (error) {
-    const errorMessage = errorParser(error);
-    res.status(400).json({ message: errorMessage });
-  }
-});
+  })
+);
 
-authController.get("/posts", isUser(), async (req, res) => {
-  try {
-    const userId = req.user?._id;
-    const ownProducts = await productService.getOwn(userId);
+authController.get(
+  "/posts",
+  isUser(),
+  asyncHandler(async (req, res) => {
+    const ownProducts = await productService.getOwn(req.user?._id);
     res.json(ownProducts);
-  } catch (error) {
-    const errorMessage = errorParser(error);
-    res.status(400).json({ message: errorMessage });
-  }
-});
+  })
+);
 
 module.exports = authController;

--- a/server/controllers/orderController.js
+++ b/server/controllers/orderController.js
@@ -1,51 +1,45 @@
 const { isUser } = require("../middlewares/guards");
+const asyncHandler = require("../util/asyncHandler");
 const orderService = require("../services/orderService");
-const errorParser = require("../util/errorParser");
 
 const orderController = require("express").Router();
 
-orderController.get("/", isUser(), async (req, res) => {
-  try {
+orderController.get(
+  "/",
+  isUser(),
+  asyncHandler(async (req, res) => {
     const orders = await orderService.getOrders(req.user?._id);
     res.json(orders);
-  } catch (error) {
-    const errorMessage = errorParser(error);
-    res.status(400).json({ message: errorMessage });
-  }
-});
+  })
+);
 
-orderController.get("/:id", isUser(), async (req, res) => {
-  try {
+orderController.get(
+  "/:id",
+  isUser(),
+  asyncHandler(async (req, res) => {
     const order = await orderService.getOrderById(req.params.id);
     res.json(order);
-  } catch (error) {
-    const errorMessage = errorParser(error);
-    res.status(400).json({ message: errorMessage });
-  }
-});
+  })
+);
 
-orderController.post("/create", isUser(), async (req, res) => {
-  try {
+orderController.post(
+  "/create",
+  isUser(),
+  asyncHandler(async (req, res) => {
     const data = req.body;
     data._ownerId = req.user._id;
-
     const order = await orderService.createOrder(data);
-
     res.json(order);
-  } catch (error) {
-    const errorMessage = errorParser(error);
-    res.status(400).json({ message: errorMessage });
-  }
-});
+  })
+);
 
-orderController.delete("/:id", isUser(), async (req, res) => {
-  try {
+orderController.delete(
+  "/:id",
+  isUser(),
+  asyncHandler(async (req, res) => {
     await orderService.deleteOrder(req.params.id);
     res.json({ message: "Successfully deleted" });
-  } catch (error) {
-    const errorMessage = errorParser(error);
-    res.status(400).json({ message: errorMessage });
-  }
-});
+  })
+);
 
 module.exports = orderController;

--- a/server/controllers/productController.js
+++ b/server/controllers/productController.js
@@ -1,23 +1,23 @@
 const { isUser, isOwner } = require("../middlewares/guards");
 const preload = require("../middlewares/preload");
+const asyncHandler = require("../util/asyncHandler");
 const wishlistService = require("../services/wishlistService");
 const productService = require("../services/productService");
-const errorParser = require("../util/errorParser");
 
 const productController = require("express").Router();
 
-productController.get("/", async (req, res) => {
-  try {
+productController.get(
+  "/",
+  asyncHandler(async (req, res) => {
     const products = await productService.getProducts(req.query);
     res.json(products);
-  } catch (error) {
-    res.status(400).json({ message: errorParser(error) });
-  }
-});
+  })
+);
 
 // Slug-or-id lookup. Slug wins; 24-char hex falls back to id lookup.
-productController.get("/:slug", async (req, res) => {
-  try {
+productController.get(
+  "/:slug",
+  asyncHandler(async (req, res) => {
     const product = await productService.getProductBySlugOrId(req.params.slug);
     if (!product) return res.status(404).json({ message: "Product not found" });
     const safeUser = product._ownerId
@@ -28,55 +28,55 @@ productController.get("/:slug", async (req, res) => {
         }
       : null;
     res.json({ ...product, _ownerId: safeUser });
-  } catch (error) {
-    res.status(400).json({ message: errorParser(error) });
-  }
-});
+  })
+);
 
-productController.post("/", isUser(), async (req, res) => {
-  try {
+productController.post(
+  "/",
+  isUser(),
+  asyncHandler(async (req, res) => {
     const data = req.body;
     data._ownerId = req.user._id;
     const product = await productService.addProduct(data);
     res.json(product);
-  } catch (error) {
-    res.status(400).json({ message: errorParser(error) });
-  }
-});
+  })
+);
 
-productController.put("/:id", preload(), isOwner(), async (req, res) => {
-  try {
+productController.put(
+  "/:id",
+  preload(),
+  isOwner(),
+  asyncHandler(async (req, res) => {
     const product = await productService.updateProduct(req.params.id, req.body);
     res.json(product);
-  } catch (error) {
-    res.status(400).json({ message: errorParser(error) });
-  }
-});
+  })
+);
 
-productController.delete("/:id", preload(), isOwner(), async (req, res) => {
-  try {
+productController.delete(
+  "/:id",
+  preload(),
+  isOwner(),
+  asyncHandler(async (req, res) => {
     await productService.deleteProduct(req.params.id);
     res.status(204).end();
-  } catch (error) {
-    res.status(400).json({ message: errorParser(error) });
-  }
-});
+  })
+);
 
-productController.post("/:id/wishlist", isUser(), async (req, res) => {
-  try {
-    const productId = req.params.id;
-    const userId = req.user?._id;
-    const user = await wishlistService.toggleItemInWishlist(userId, productId);
-    const safeUser = {
+productController.post(
+  "/:id/wishlist",
+  isUser(),
+  asyncHandler(async (req, res) => {
+    const user = await wishlistService.toggleItemInWishlist(
+      req.user?._id,
+      req.params.id
+    );
+    res.json({
       _id: user._id,
       email: user.email,
       username: user.username,
       wishlist: user.wishlist,
-    };
-    res.json(safeUser);
-  } catch (error) {
-    res.status(400).json({ message: errorParser(error) });
-  }
-});
+    });
+  })
+);
 
 module.exports = productController;

--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ const config = require("./config/express.js");
 const authController = require("./controllers/authController.js");
 const productController = require("./controllers/productController.js");
 const orderController = require("./controllers/orderController.js");
+const errorHandler = require("./middlewares/errorHandler.js");
 
 start();
 async function start() {
@@ -14,6 +15,8 @@ async function start() {
   app.use("/auth", authController);
   app.use("/products", productController);
   app.use("/orders", orderController);
+
+  app.use(errorHandler);
 
   app.listen(3030, () => {
     console.log(`Listening on port 3030`);

--- a/server/middlewares/errorHandler.js
+++ b/server/middlewares/errorHandler.js
@@ -1,0 +1,35 @@
+const errorParser = require("../util/errorParser");
+
+// Single place that turns thrown errors into HTTP responses.
+// Known shapes map to specific status codes; anything unrecognized is a 500
+// with a generic message so internal details are not leaked to clients.
+module.exports = (err, req, res, next) => {
+  // express-validator collects errors into an array.
+  if (Array.isArray(err)) {
+    return res.status(422).json({ message: errorParser(err) });
+  }
+
+  // Mongoose schema validation.
+  if (err.name === "ValidationError") {
+    return res.status(422).json({ message: errorParser(err) });
+  }
+
+  // Malformed ObjectId / cast failure.
+  if (err.name === "CastError") {
+    return res.status(400).json({ message: "Invalid identifier" });
+  }
+
+  // Mongoose duplicate key (e.g. unique email under a race).
+  if (err.code === 11000) {
+    return res.status(409).json({ message: "Resource already exists" });
+  }
+
+  // AppError (or anything carrying an explicit numeric status).
+  if (typeof err.status === "number") {
+    return res.status(err.status).json({ message: err.message });
+  }
+
+  // Unexpected: log for the server, return a generic 500 to the client.
+  console.error("[error]", err);
+  return res.status(500).json({ message: "Something went wrong" });
+};

--- a/server/middlewares/rateLimit.js
+++ b/server/middlewares/rateLimit.js
@@ -1,0 +1,12 @@
+const rateLimit = require("express-rate-limit");
+
+// Throttle credential endpoints to slow brute-force / credential-stuffing.
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 20, // per IP per window
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { message: "Too many attempts, please try again later" },
+});
+
+module.exports = { authLimiter };

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,7 +14,9 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-rate-limit": "^8.5.2",
         "express-validator": "^7.0.1",
+        "helmet": "^8.2.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.0.1"
       }
@@ -481,6 +483,24 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express-validator": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.0.1.tgz",
@@ -677,6 +697,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -749,6 +781,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -2008,6 +2049,14 @@
         "vary": "~1.1.2"
       }
     },
+    "express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "requires": {
+        "ip-address": "^10.2.0"
+      }
+    },
     "express-validator": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.0.1.tgz",
@@ -2149,6 +2198,11 @@
         "function-bind": "^1.1.2"
       }
     },
+    "helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q=="
+    },
     "http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -2206,6 +2260,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="
     },
     "ipaddr.js": {
       "version": "1.9.1",

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,9 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-rate-limit": "^8.5.2",
     "express-validator": "^7.0.1",
+    "helmet": "^8.2.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.0.1"
   }

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -2,6 +2,7 @@ const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
 const User = require("../models/User");
 const { jwtSecret: secret } = require("../config/env");
+const AppError = require("../util/AppError");
 
 const TOKEN_TTL = "7d";
 
@@ -11,12 +12,12 @@ async function login(email, password) {
     strength: 2,
   });
   if (!existingUser) {
-    throw new Error("Invalid email or password");
+    throw new AppError("Invalid email or password", 401);
   }
 
   const matchPass = await bcrypt.compare(password, existingUser.hashedPassword);
   if (!matchPass) {
-    throw new Error("Invalid email or password");
+    throw new AppError("Invalid email or password", 401);
   }
 
   return createToken(existingUser);
@@ -29,7 +30,7 @@ async function register(username, email, password) {
   });
 
   if (existingUser) {
-    throw new Error("This email is already taken");
+    throw new AppError("This email is already taken", 409);
   }
 
   const user = await User.create({

--- a/server/services/orderService.js
+++ b/server/services/orderService.js
@@ -1,5 +1,6 @@
 const Order = require("../models/Order");
 const Product = require("../models/Product");
+const AppError = require("../util/AppError");
 
 async function getOrders(userId) {
   const orders = await Order.find({ _ownerId: userId })
@@ -20,7 +21,7 @@ async function createOrder(data) {
     const product = await Product.findById(p.product).lean();
 
     if (product._ownerId == data._ownerId) {
-      throw new Error("You can't buy your own product");
+      throw new AppError("You can't buy your own product", 400);
     }
 
     return (await acc) + product.price * p.count;

--- a/server/services/wishlistService.js
+++ b/server/services/wishlistService.js
@@ -1,12 +1,13 @@
 const Product = require("../models/Product");
 const User = require("../models/User");
+const AppError = require("../util/AppError");
 
 async function toggleItemInWishlist(userId, productId) {
   const user = await User.findById(userId);
   const product = await Product.findById(productId);
 
   if (product._ownerId.toString() == userId) {
-    throw new Error("You can't add your own product to the wishlist");
+    throw new AppError("You can't add your own product to the wishlist", 400);
   }
 
   const productInWishlist = user.wishlist.find((prodId) => {

--- a/server/util/AppError.js
+++ b/server/util/AppError.js
@@ -1,0 +1,11 @@
+// Domain error carrying an HTTP status, so services can signal intent
+// (401/403/404/409/...) without each controller mapping messages by hand.
+class AppError extends Error {
+  constructor(message, status = 400) {
+    super(message);
+    this.name = "AppError";
+    this.status = status;
+  }
+}
+
+module.exports = AppError;

--- a/server/util/asyncHandler.js
+++ b/server/util/asyncHandler.js
@@ -1,0 +1,4 @@
+// Express 4 does not forward rejected promises from async handlers to the
+// error middleware. Wrap handlers so any throw/rejection reaches next(err).
+module.exports = (fn) => (req, res, next) =>
+  Promise.resolve(fn(req, res, next)).catch(next);


### PR DESCRIPTION
Two related server improvements. Off `main`.

### #5 — Security hardening
- `helmet()` for standard security headers.
- `express-rate-limit` on `/auth` login + register (20 / 15 min per IP).
- 100kb request body cap.

### #10/#11 — Centralized error handling
- `asyncHandler` wrapper removes per-handler try/catch across all controllers.
- Single `errorHandler` maps error shapes to real status codes:
  validation → 422, bad id → 400, duplicate → 409, domain `AppError` →
  401/403/409, unexpected → 500 (generic message, logged server-side).
- Services throw `AppError` carrying intent instead of bare `Error`.

### Behavioral note
Error responses now return accurate status codes instead of always 400.
Response body `{ message }` and all user-facing messages are unchanged.

### Not included
The 17 `npm audit` findings (stale deps) are a separate modernization item.