### PR TITLE
Fix/server data layer

### DIFF
--- a/server/config/express.js
+++ b/server/config/express.js
@@ -23,6 +23,7 @@ module.exports = async (app) => {
         "https://dream-furniture-1e92c.web.app",
       ],
       credentials: true,
+      exposedHeaders: ["X-Total-Count"],
     })
   );
   app.use(session());

--- a/server/controllers/productController.js
+++ b/server/controllers/productController.js
@@ -9,8 +9,9 @@ const productController = require("express").Router();
 productController.get(
   "/",
   asyncHandler(async (req, res) => {
-    const products = await productService.getProducts(req.query);
-    res.json(products);
+    const { items, total } = await productService.getProducts(req.query);
+    res.set("X-Total-Count", String(total));
+    res.json(items);
   })
 );
 

--- a/server/middlewares/guards.js
+++ b/server/middlewares/guards.js
@@ -20,9 +20,10 @@ function isGuest() {
 
 function isOwner() {
   return (req, res, next) => {
+    const ownerId = res.locals.product?._ownerId?._id;
     const userId = req.user?._id;
 
-    if (res.locals.product?._ownerId?._id == userId) {
+    if (ownerId && userId && String(ownerId) === String(userId)) {
       next();
     } else {
       res.status(403).json({ message: "You are not the owner of this post" });

--- a/server/services/productService.js
+++ b/server/services/productService.js
@@ -35,7 +35,10 @@ async function getProducts(query) {
   let q = Product.find(queryObj).sort(query.sort || null);
   if (query.offset) q = q.skip(Number(query.offset));
   if (query.limit) q = q.limit(Number(query.limit));
-  return await q;
+
+  // total = full match count ignoring limit/offset, for pagination.
+  const [items, total] = await Promise.all([q, Product.countDocuments(queryObj)]);
+  return { items, total };
 }
 
 async function getProductById(productId) {

--- a/server/services/wishlistService.js
+++ b/server/services/wishlistService.js
@@ -3,27 +3,22 @@ const User = require("../models/User");
 const AppError = require("../util/AppError");
 
 async function toggleItemInWishlist(userId, productId) {
-  const user = await User.findById(userId);
-  const product = await Product.findById(productId);
-
-  if (product._ownerId.toString() == userId) {
+  const product = await Product.findById(productId).select("_ownerId");
+  if (!product) {
+    throw new AppError("Product not found", 404);
+  }
+  if (String(product._ownerId) === String(userId)) {
     throw new AppError("You can't add your own product to the wishlist", 400);
   }
 
-  const productInWishlist = user.wishlist.find((prodId) => {
-    return prodId == productId;
-  });
+  // Atomic field-level toggle: pull if already present, otherwise add.
+  // Avoids the load-filter-save race that can drop concurrent updates.
+  const present = await User.exists({ _id: userId, wishlist: productId });
+  const update = present
+    ? { $pull: { wishlist: productId } }
+    : { $addToSet: { wishlist: productId } };
 
-  if (productInWishlist) {
-    //remove from wish list
-    user.wishlist = user.wishlist.filter((prodId) => prodId != productId);
-  } else {
-    //add to wishlist
-    user.wishlist.push(productId);
-  }
-
-  const newUser = await user.save();
-  return newUser;
+  return await User.findByIdAndUpdate(userId, update, { new: true });
 }
 
 async function getWishlist(userId) {


### PR DESCRIPTION
Three small data-layer correctness/robustness fixes. Off `main`.

- **#14** `isOwner` compares ObjectIds by value with null-safety (was loose `==`).
- **#13** Wishlist toggle is atomic via `$addToSet`/`$pull` — no more
  load-filter-save race. Missing product now returns 404; no duplicate entries.
- **#15** `/products` exposes the full match count via an `X-Total-Count`
  response header (exposed through CORS). Non-breaking: body stays a plain
  array; the message/array shape is unchanged.

### Verification
Integration-tested against MongoDB: pagination total ignores limit and
reflects filters; wishlist add/remove/no-dup/own-product(400)/missing(404);
ObjectId match/mismatch/null cases.