### PR TITLE
validate product, order, and register bodies at the edge

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -2,15 +2,14 @@ const authService = require("../services/authService");
 const { authCookieName } = require("../config/cookie.js");
 const asyncHandler = require("../util/asyncHandler.js");
 
-const { body, validationResult } = require("express-validator");
 const { isGuest, isUser } = require("../middlewares/guards.js");
 const { authLimiter } = require("../middlewares/rateLimit.js");
+const { registerValidators } = require("../middlewares/validators.js");
+const validate = require("../middlewares/validate.js");
 const wishlistService = require("../services/wishlistService.js");
 const productService = require("../services/productService.js");
 
 const authController = require("express").Router();
-
-const emailPattern = "[a-zA-Z0-9]{5,}@[a-zA-Z]+.[a-zA-Z]{2,}$";
 
 const cookieOptions =
   process.env.NODE_ENV == "production"
@@ -37,19 +36,9 @@ authController.post(
   "/register",
   authLimiter,
   isGuest(),
-  body("email").matches(emailPattern).withMessage("Invalid email"),
-  body("username")
-    .isLength({ min: 5 })
-    .withMessage("Username must be atleast 5 characters long"),
-  body("password")
-    .isLength({ min: 6 })
-    .withMessage("Password must be atleast 6 characters long"),
+  ...registerValidators,
+  validate,
   asyncHandler(async (req, res) => {
-    const errors = validationResult(req).errors;
-    if (errors.length > 0) {
-      throw errors;
-    }
-
     const { username, email, password } = req.body;
     const { user, authToken } = await authService.register(
       username,

--- a/server/controllers/orderController.js
+++ b/server/controllers/orderController.js
@@ -1,5 +1,7 @@
 const { isUser } = require("../middlewares/guards");
 const asyncHandler = require("../util/asyncHandler");
+const { orderValidators } = require("../middlewares/validators");
+const validate = require("../middlewares/validate");
 const orderService = require("../services/orderService");
 
 const orderController = require("express").Router();
@@ -25,6 +27,8 @@ orderController.get(
 orderController.post(
   "/create",
   isUser(),
+  ...orderValidators,
+  validate,
   asyncHandler(async (req, res) => {
     const data = req.body;
     data._ownerId = req.user._id;

--- a/server/controllers/productController.js
+++ b/server/controllers/productController.js
@@ -1,6 +1,8 @@
 const { isUser, isOwner } = require("../middlewares/guards");
 const preload = require("../middlewares/preload");
 const asyncHandler = require("../util/asyncHandler");
+const { productValidators } = require("../middlewares/validators");
+const validate = require("../middlewares/validate");
 const wishlistService = require("../services/wishlistService");
 const productService = require("../services/productService");
 
@@ -35,6 +37,8 @@ productController.get(
 productController.post(
   "/",
   isUser(),
+  ...productValidators,
+  validate,
   asyncHandler(async (req, res) => {
     const data = req.body;
     data._ownerId = req.user._id;
@@ -47,6 +51,8 @@ productController.put(
   "/:id",
   preload(),
   isOwner(),
+  ...productValidators,
+  validate,
   asyncHandler(async (req, res) => {
     const product = await productService.updateProduct(req.params.id, req.body);
     res.json(product);

--- a/server/middlewares/validate.js
+++ b/server/middlewares/validate.js
@@ -1,0 +1,11 @@
+const { validationResult } = require("express-validator");
+
+// Runs after express-validator checks. Forwards collected errors as an array
+// to the central error handler (which maps it to 422).
+module.exports = (req, res, next) => {
+  const result = validationResult(req);
+  if (!result.isEmpty()) {
+    return next(result.array());
+  }
+  next();
+};

--- a/server/middlewares/validators.js
+++ b/server/middlewares/validators.js
@@ -1,0 +1,50 @@
+const { body } = require("express-validator");
+
+const emailPattern = "[a-zA-Z0-9]{5,}@[a-zA-Z]+.[a-zA-Z]{2,}$";
+
+const registerValidators = [
+  body("email").matches(emailPattern).withMessage("Invalid email"),
+  body("username")
+    .isLength({ min: 5 })
+    .withMessage("Username must be atleast 5 characters long"),
+  body("password")
+    .isLength({ min: 6 })
+    .withMessage("Password must be atleast 6 characters long"),
+];
+
+// Shared by create (POST) and update (PUT) — both write the full document.
+// Allowed category values are still enforced by the Mongoose schema.
+const productValidators = [
+  body("name").trim().notEmpty().withMessage("Name is required"),
+  body("description").trim().notEmpty().withMessage("Description is required"),
+  body("shortDescription")
+    .trim()
+    .notEmpty()
+    .withMessage("Short description is required")
+    .isLength({ max: 200 })
+    .withMessage("Short description must be 200 characters or fewer"),
+  body("images").isArray({ min: 1 }).withMessage("At least one image is required"),
+  body("category").isArray({ min: 1 }).withMessage("At least one category is required"),
+  body("style").trim().notEmpty().withMessage("Style is required"),
+  body("dimensions.width").isNumeric().withMessage("Width must be a number"),
+  body("dimensions.height").isNumeric().withMessage("Height must be a number"),
+  body("dimensions.depth").isNumeric().withMessage("Depth must be a number"),
+  body("material").isArray({ min: 1 }).withMessage("At least one material is required"),
+  body("color").trim().notEmpty().withMessage("Color is required"),
+  body("price").isFloat({ gt: 0 }).withMessage("Price must be a positive number"),
+  body("tags").optional().isArray().withMessage("Tags must be an array"),
+  body("inStock").optional().isBoolean().withMessage("inStock must be a boolean"),
+  body("isFeatured").optional().isBoolean().withMessage("isFeatured must be a boolean"),
+];
+
+const orderValidators = [
+  body("products")
+    .isArray({ min: 1 })
+    .withMessage("Order must contain at least one product"),
+  body("products.*.product").isMongoId().withMessage("Invalid product id in order"),
+  body("products.*.count")
+    .isInt({ gt: 0 })
+    .withMessage("Product count must be a positive integer"),
+];
+
+module.exports = { registerValidators, productValidators, orderValidators };


### PR DESCRIPTION
Adds consistent request-body validation to product/order creation (and PUT
product), matching what `/register` already did. Off `main`.

- New `middlewares/validators.js`: registerValidators, productValidators
  (POST + PUT), orderValidators.
- New `middlewares/validate.js`: runs the chains and forwards errors to the
  central handler (422).
- Register refactored onto the shared validators (drops its inline check).

Allowed category values remain enforced by the Mongoose schema.