### PR TITLE
Batch product lookups when creating an order

### DIFF
--- a/server/src/services/orderService.ts
+++ b/server/src/services/orderService.ts
@@ -19,15 +19,25 @@ export async function getOrderById(orderId: string) {
 }
 
 export async function createOrder(data: OrderInput) {
-  data.totalPrice = await data.products.reduce<Promise<number>>(async (acc, p) => {
-    const product = await Product.findById(p.product).lean();
+  // Fetch every referenced product in one query instead of N sequential lookups.
+  const ids = data.products.map((p) => p.product);
+  const products = await Product.find({ _id: { $in: ids } })
+    .select("price _ownerId")
+    .lean();
+  const byId = new Map(products.map((p) => [String(p._id), p]));
+
+  // Compute the total server-side; never trust a client-supplied price.
+  let totalPrice = 0;
+  for (const item of data.products) {
+    const product = byId.get(String(item.product));
     if (!product) throw new AppError("Product not found", 404);
     if (String(product._ownerId) === String(data._ownerId)) {
       throw new AppError("You can't buy your own product", 400);
     }
-    return (await acc) + product.price * p.count;
-  }, Promise.resolve(0));
+    totalPrice += product.price * item.count;
+  }
 
+  data.totalPrice = totalPrice;
   return Order.create(data);
 }
 


### PR DESCRIPTION
Replace the N sequential `findById` lookups in `createOrder` with a single `$in` query + in-memory total computation. Behavior unchanged: server-side total, missing product → 404, own-product → 400.

No transaction: order creation writes one document and mutates nothing else, so it's already atomic. Verified the total, the 404/400 guards, and that exactly one Product query runs.