### PR TITLE
Fix duplicate email index on User schema

### DIFF
--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -8,13 +8,19 @@ export interface IUser {
 }
 
 const userSchema = new Schema<IUser>({
-  email: { type: String, required: true, unique: true },
+  email: { type: String, required: true },
   username: { type: String, required: true },
   wishlist: { type: [Types.ObjectId], ref: "Product", default: [] },
   hashedPassword: { type: String, required: true },
 });
 
-userSchema.index({ email: 1 }, { collation: { locale: "en", strength: 2 } });
+// Single index definition: unique + case-insensitive (matches the collation
+// used by the login/register lookups). Replaces the field-level `unique: true`
+// that previously collided with this declaration.
+userSchema.index(
+  { email: 1 },
+  { unique: true, collation: { locale: "en", strength: 2 } }
+);
 
 const User = model<IUser>("User", userSchema);
 export default User;


### PR DESCRIPTION
Silences the Mongoose startup warning:
`Duplicate schema index on {"email":1} found.`

The User schema declared an index on `email` twice — implicitly via `unique: true` on the field, and again via `schema.index({ email: 1 }, { collation })`. Consolidated into a single definition with all options on the `schema.index()` call: **unique + the case-insensitive collation** the login/register lookups already use.

### Verification
- `npm run typecheck` 0 · `npm run build` 0 · `npm test` 3/3
- No "Duplicate schema index" warning on model load.
- Integration check: exactly one `email` index (unique + collation); a case-variant duplicate (`Buyer@X.io` vs `buyer@x.io`) is now rejected at the DB with E11000.

### One-time prod note (Atlas)
The existing `email_1` index in production has different options than this new definition. With autoIndex on, the next deploy may log a benign `index already exists with different options` message. To apply it cleanly, drop the old index once and let it rebuild:
```
db.users.dropIndex("email_1")   // then restart/redeploy; autoIndex recreates it as unique+collation
```
The app keeps working throughout — login/register match case-insensitively via the query collation regardless of the index. (Assumes no pre-existing case-variant duplicate emails, which the app's registration check already prevents.)